### PR TITLE
Add bash-completion to supernova

### DIFF
--- a/contrib/supernova-completion.bash
+++ b/contrib/supernova-completion.bash
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+_supernova()
+{
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local possibilities=$(awk '/\[/{ gsub(/\[|\]/,"");print}' ~/.supernova)
+    COMPREPLY=( $(compgen -W "${possibilities}" -- $cur) )
+}
+complete -F _supernova supernova

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         'console_scripts': [
             'supernova = supernova.executable:run_supernova',
             'supernova-keyring = supernova.executable:run_supernova_keyring'],
-        }
+        },
+    data_files=[('/etc/bash_completion.d/',['contrib/supernova-completion.bash'])]
     )


### PR DESCRIPTION
This commit adds a contrib/supernova-completion.bash file that gets installed into /etc/bash_completion.d/ that adds autocompletion for supernova environments.
