### PR TITLE
unicode keyring problem on windows

### DIFF
--- a/supernova/supernova.py
+++ b/supernova/supernova.py
@@ -69,7 +69,7 @@ class SuperNova:
         configuration parameter pair.
         """
         try:
-            return keyring.get_password('supernova', username)
+            return keyring.get_password('supernova', username).encode('ascii')
         except:
             return False
 


### PR DESCRIPTION
There is a unicode issue with Windows 8 at a minimum when using supernova-keyring.  The .encode('ascii') on retreiving the info via the keyring fixed the problem for windows and I tested it on OSX and there was no problem.
