### PR TITLE
fix(README): add pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ If any of these complaints ring true, *supernova* is for you. *supernova* manage
 
 ![First world problems - nova style](https://skitch.mhtx.net/firstworldproblems-multiplenovaenvironments-20120316-072224.jpg)
 
-### Installation
+### Quick Install from pip
+
+    pip install keyring
+    pip install supernova
+    
+### Install from Git
 
     git clone git://github.com/major/supernova.git
     cd supernova


### PR DESCRIPTION
Let people quickly install from pip. On OSX I think the deps are messed up since keyring needs to be installed first.
