### PR TITLE
support running client commands other than nova

### DIFF
--- a/supernova/executable.py
+++ b/supernova/executable.py
@@ -86,6 +86,8 @@ def run_supernova():
     check_supernova_conf(s)
 
     parser = argparse.ArgumentParser()
+    parser.add_argument('-x', '--executable', default='nova',
+                        help='command to run instead of nova')
     parser.add_argument('-l', '--list', action=_ListAction,
                         dest='listenvs',
                         help='list all configured environments')
@@ -108,7 +110,7 @@ def run_supernova():
     setup_supernova_env(s, supernova_args.env)
 
     # All of the remaining arguments should be handed off to nova
-    return s.run_novaclient(nova_args, supernova_args.debug)
+    return s.run_novaclient(nova_args, supernova_args)
 
 
 def run_supernova_keyring():

--- a/supernova/supernova.py
+++ b/supernova/supernova.py
@@ -134,7 +134,7 @@ class SuperNova:
         for k, v in self.prep_nova_creds():
             self.env[k] = v
 
-    def run_novaclient(self, nova_args, force_debug=False):
+    def run_novaclient(self, nova_args, supernova_args):
         """
         Sets the environment variables for novaclient, runs novaclient, and
         prints the output.
@@ -143,7 +143,7 @@ class SuperNova:
         self.prep_shell_environment()
 
         # Check for a debug override
-        if force_debug:
+        if supernova_args.debug:
             nova_args.insert(0, '--debug')
 
         # Call novaclient and connect stdout/stderr to the current terminal
@@ -151,7 +151,7 @@ class SuperNova:
         # displayed appropriately.
         #
         # In other news, I hate how python 2.6 does unicode.
-        p = subprocess.Popen(['nova'] + nova_args,
+        p = subprocess.Popen([supernova_args.executable] + nova_args,
             stdout=sys.stdout,
             stderr=sys.stderr,
             env=self.env


### PR DESCRIPTION
This allows supernova to be used with other clients that work in similar ways, such as clients for other parts of the openstack project.
