### PR TITLE
fix per using supernova.supernova.SuperNova.get_novaclient()

### DIFF
--- a/supernova/supernova.py
+++ b/supernova/supernova.py
@@ -172,7 +172,7 @@ class SuperNova:
         """
         self.nova_env = env
         assert self.is_valid_environment(), "Env %s not found in config." % env
-        return novaclient.Client(**self.prep_python_creds())
+        return novaclient.Client('3', **self.prep_python_creds())
 
     def prep_python_creds(self):
         """
@@ -186,6 +186,8 @@ class SuperNova:
             creds['auth_url'] = creds.pop('url')
         if creds.get('tenant_name'):
             creds['project_id'] = creds.pop('tenant_name')
+        if creds.get('rax_auth'):
+            creds.pop('rax_auth')
         return creds
 
 


### PR DESCRIPTION
- novaclient.Client doesn't like having the rax_auth entry in the creds dictionary
- novaclient.Client() requires either (i) a version be specified, or (ii) the correct version be imported; specifying the version seems to be easier to maintain than changing the import statement. Opted for the latest version (3), but doesn't really matter whether it's '1_1', '2', or '3' (see novaclient's novaclient.client.py).
