### PR TITLE
respect XDG_CONFIG_HOME

### DIFF
--- a/supernova/config.py
+++ b/supernova/config.py
@@ -58,7 +58,11 @@ def load_supernova_config():
     """
     Pulls the supernova configuration file and reads it
     """
-    possible_configs = [os.path.expanduser('~/.supernova'), '.supernova']
+    xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or \
+                      os.path.expanduser('~/.config')
+    possible_configs = [os.path.join(xdg_config_home, "supernova"),
+                        os.path.expanduser("~/.supernova"),
+                        ".supernova"]
     supernova_config = ConfigParser.RawConfigParser()
 
     # Can we successfully read the configuration file?


### PR DESCRIPTION
Add support for the XDG Base Directory Specification.

http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html

The previous locations are still supported, but users can opt to move their config file from ~/.supernova to ~/.config/supernova for a cleaner home directory.
