### PR TITLE
Python 3 support

### DIFF
--- a/supernova/config.py
+++ b/supernova/config.py
@@ -18,11 +18,15 @@
 Takes care of the basic setup of the config files and does some preliminary
 sanity checks
 """
-import ConfigParser
+try:
+    import ConfigParser
+except:
+    import configparser as ConfigParser
+
 import os
 import sys
 
-from colors import rwrap
+from . import colors
 
 nova_creds = None
 
@@ -45,12 +49,12 @@ def check_environment_presets():
     if len(presets) < 1:
         return True
     else:
-        print "_" * 80
-        print "*WARNING* Found existing environment variables that may "\
-              "cause conflicts:"
+        print("_" * 80)
+        print("*WARNING* Found existing environment variables that may ",
+              "cause conflicts:")
         for preset in presets:
-            print "  - %s" % preset
-        print "_" * 80
+            print("  - %s" % preset)
+        print("_" * 80)
         return False
 
 
@@ -59,7 +63,7 @@ def load_supernova_config():
     Pulls the supernova configuration file and reads it
     """
     xdg_config_home = os.environ.get('XDG_CONFIG_HOME') or \
-                      os.path.expanduser('~/.config')
+        os.path.expanduser('~/.config')
     possible_configs = [os.path.join(xdg_config_home, "supernova"),
                         os.path.expanduser("~/.supernova"),
                         ".supernova"]
@@ -73,8 +77,8 @@ def load_supernova_config():
 [%s] A valid supernova configuration file is required.
 Ensure that you have a properly configured supernova configuration file called
 '.supernova' in your home directory or in your current working directory.
-""" % rwrap('Invalid configuration file')
-        print msg
+""" % colors.rwrap('Invalid configuration file')
+        print(msg)
         sys.exit(1)
 
     return supernova_config

--- a/supernova/credentials.py
+++ b/supernova/credentials.py
@@ -17,13 +17,22 @@
 """
 Handles all of the interactions with the operating system's keyring
 """
+from __future__ import print_function
+
 import getpass
 import keyring
 import re
 import sys
 
+try:
+    def _input(a):
+        input(a)
+except:
+    def _input(a):
+        raw_input(a)
 
-from colors import gwrap, rwrap
+
+from . import colors
 
 
 def get_user_password(args):
@@ -33,8 +42,8 @@ def get_user_password(args):
     """
     username = '%s:%s' % (args.env, args.parameter)
 
-    warnstring = rwrap("__ WARNING ".ljust(80, '_'))
-    print """
+    warnstring = colors.rwrap("__ WARNING ".ljust(80, '_'))
+    print("""
 %s
 
 If this operation is successful, the credential stored for this username will
@@ -47,18 +56,18 @@ any concerns about having this credential displayed on your screen, press
 CTRL-C right now.
 
 %s
-""" % (warnstring, username, warnstring)
-    print "If you are completely sure you want to display it, type 'yes' and "\
-          "press enter:",
+""" % (warnstring, username, warnstring))
+    print("If you are completely sure you want to display it, type 'yes' and ",
+          "press enter:")
     try:
-        confirm = raw_input('')
+        confirm = _input('')
     except:
-        print ""
+        print("")
         sys.exit()
 
     if confirm != 'yes':
-        print "\n[%s] Your keyring was not read or altered." % (
-            rwrap("Canceled"))
+        print("\n[%s] Your keyring was not read or altered." % (
+            colors.rwrap("Canceled")))
         return False
 
     try:
@@ -67,20 +76,20 @@ CTRL-C right now.
         password = None
 
     if password:
-        print """
+        print("""
 [%s] Found credentials for %s: %s
 """ % (
-            gwrap("Success"), username, password)
+            colors.gwrap("Success"), username, password))
         return True
     else:
-        print """
+        print("""
 [%s] Unable to retrieve credentials for %s.
 
 It's likely that there aren't any credentials stored for this environment and
 parameter combination.  If you want to set a credential, just run this command:
 
   supernova-keyring -s %s %s
-""" % (rwrap("Failed"), username, args.env, args.parameter)
+""" % (colors.rwrap("Failed"), username, args.env, args.parameter))
         return False
 
 
@@ -113,27 +122,27 @@ def set_user_password(args):
     """
     Sets a user's password in the keyring storage
     """
-    print """
+    print("""
 [%s] Preparing to set a password in the keyring for:
 
   - Environment  : %s
   - Parameter    : %s
 
 If this is correct, enter the corresponding credential to store in your keyring
-or press CTRL-D to abort:""" % (gwrap("Keyring operation"), args.env,
-                                args.parameter)
+or press CTRL-D to abort:""" % (colors.gwrap("Keyring operation"), args.env,
+                                args.parameter))
 
     # Prompt for a password and catch a CTRL-D
     try:
         password = getpass.getpass('')
     except:
         password = None
-        print
+        print()
 
     # Did we get a password from the prompt?
     if not password or len(password) < 1:
-        print "\n[%s] No data was altered in your keyring.\n" % (
-            rwrap("Canceled"))
+        print("\n[%s] No data was altered in your keyring.\n" % (
+            colors.rwrap("Canceled")))
         sys.exit()
 
     # Try to store the password
@@ -144,11 +153,11 @@ or press CTRL-D to abort:""" % (gwrap("Keyring operation"), args.env,
         store_ok = False
 
     if store_ok:
-        print "[%s] Successfully stored credentials for %s under the " \
-              "supernova service.\n" % (gwrap("Success"), username)
+        print("[%s] Successfully stored credentials for %s under the ",
+              "supernova service.\n" % (colors.gwrap("Success"), username))
     else:
-        print "[%s] Unable to store credentials for %s under the " \
-              "supernova service.\n" % (rwrap("Failed"), username)
+        print("[%s] Unable to store credentials for %s under the ",
+              "supernova service.\n" % (colors.rwrap("Failed"), username))
 
 
 def password_set(username=None, password=None):

--- a/supernova/executable.py
+++ b/supernova/executable.py
@@ -18,15 +18,17 @@
 Contains the functions needed for supernova and supernova-keyring commands
 to run
 """
+from __future__ import print_function
+
 import argparse
 import sys
 
 
-from colors import gwrap
-import config
-import credentials
-import utils
-from supernova import SuperNova
+from . import colors
+from . import config
+from . import credentials
+from . import utils
+from . import supernova
 
 
 # Note(tr3buchet): this is necessary to prevent argparse from requiring the
@@ -36,10 +38,10 @@ class _ListAction(argparse._HelpAction):
     def __call__(self, parser, *args, **kwargs):
         """Lists are configured supernova environments."""
         for nova_env in config.nova_creds.sections():
-            envheader = '-- %s ' % gwrap(nova_env)
-            print envheader.ljust(86, '-')
+            envheader = '-- %s ' % colors.gwrap(nova_env)
+            print(envheader.ljust(86, '-'))
             for param, value in sorted(config.nova_creds.items(nova_env)):
-                print '  %s: %s' % (param.upper().ljust(21), value)
+                print('  %s: %s' % (param.upper().ljust(21), value))
         parser.exit()
 
 
@@ -76,7 +78,7 @@ def run_supernova():
     else:
         envs = [supernova_args.env]
 
-    snobj = SuperNova()
+    snobj = supernova.SuperNova()
     for env in envs:
         snobj.nova_env = env
         snobj.run_novaclient(nova_args, supernova_args)

--- a/supernova/supernova.py
+++ b/supernova/supernova.py
@@ -18,6 +18,9 @@
 Contains the actual class that runs novaclient (or the executable chosen by
 the user)
 """
+from __future__ import print_function
+
+
 from novaclient import client as novaclient
 import os
 import re
@@ -25,9 +28,10 @@ import subprocess
 import sys
 
 
-from colors import gwrap
-import config
-import credentials
+from . import colors
+from . import utils
+from . import config
+from . import credentials
 
 
 class SuperNova(object):
@@ -74,7 +78,7 @@ credentials for %s yet, try running:
 
     supernova-keyring -s %s
 """ % (self.nova_env, username, username, ' '.join(username.split(':')))
-                print msg
+                print(msg)
                 sys.exit(1)
 
             creds.append((param, credential))
@@ -111,7 +115,7 @@ credentials for %s yet, try running:
         # Print a small message for the user (very helpful for groups)
         msg = "Running %s against %s..." % (supernova_args.executable,
                                             self.nova_env)
-        print "[%s] %s " % (gwrap('SUPERNOVA'), msg)
+        print("[%s] %s " % (colors.gwrap('SUPERNOVA'), msg))
 
         # Call novaclient and connect stdout/stderr to the current terminal
         # so that any unicode characters from novaclient's list will be
@@ -133,7 +137,7 @@ credentials for %s yet, try running:
         self.nova_env = env
         assert utils.is_valid_environment(env), "Env %s not found in "\
             "supernova configuration file." % env
-        print "Getting novaclient!"
+        print("Getting novaclient!")
         return novaclient.Client(client_version, **self.prep_python_creds())
 
     def prep_python_creds(self):

--- a/supernova/utils.py
+++ b/supernova/utils.py
@@ -17,12 +17,10 @@
 """
 Contains many of the shared utility functions
 """
-import argparse
-import sys
+from __future__ import print_function
 
-
-from colors import gwrap, rwrap
-import config
+from . import colors
+from . import config
 
 
 def check_deprecated_options(self):
@@ -32,8 +30,8 @@ def check_deprecated_options(self):
     """
     creds = config.nova_creds
     if creds.has_option(self.nova_env, 'insecure'):
-        print "WARNING: the 'insecure' option is deprecated. " \
-              "Consider using NOVACLIENT_INSECURE=1 instead."
+        print("WARNING: the 'insecure' option is deprecated. ",
+              "Consider using NOVACLIENT_INSECURE=1 instead.")
 
 
 def get_envs_in_group(group_name):
@@ -80,8 +78,9 @@ def print_valid_envs(valid_envs):
     """
     Prints the available environments.
     """
-    print "[%s] Your valid environments are:" % (gwrap('Found environments'))
-    print "%r" % valid_envs
+    print("[%s] Your valid environments are:" %
+          (colors.gwrap('Found environments')))
+    print("%r" % valid_envs)
 
 
 def warn_missing_nova_args():
@@ -101,7 +100,7 @@ Here are some example commands that may help you get started:
   supernova prod image-list
   supernova prod keypair-list
 """
-    print msg % rwrap('Missing arguments')
+    print(msg % colors.rwrap('Missing arguments'))
 
 
 def rm_prefix(name):


### PR DESCRIPTION
- Change all 'print's to 'print()' and add the print_function future
  import to the files that use it.
- Import the configparser module as ConfigParser if we don't have
  ConfigParser (which was renamed in python 3).
- Change the imports::
  - We have no module named 'colors' when this package is installed, it
    needs to be a relative import to the root of the package, so use
    ''from . import <module>'' to get this done correctly.
  - Change the colors imports to explicitly say 'colors.rwrap' or
    'colors.gwrap'

This should allow supernova to run flawlessly in a python3 environment.
