### PR TITLE
correct TypeError with string formatting

### DIFF
--- a/supernova/credentials.py
+++ b/supernova/credentials.py
@@ -153,11 +153,13 @@ or press CTRL-D to abort:""" % (colors.gwrap("Keyring operation"), args.env,
         store_ok = False
 
     if store_ok:
-        print("[%s] Successfully stored credentials for %s under the ",
-              "supernova service.\n" % (colors.gwrap("Success"), username))
+        msg = ("[%s] Successfully stored credentials for %s under the "
+               "supernova service.\n")
+        print(msg % (colors.gwrap("Success"), username))
     else:
-        print("[%s] Unable to store credentials for %s under the ",
-              "supernova service.\n" % (colors.rwrap("Failed"), username))
+        msg = ("[%s] Unable to store credentials for %s under the "
+               "supernova service.\n")
+        print(msg % (colors.rwrap("Failed"), username))
 
 
 def password_set(username=None, password=None):


### PR DESCRIPTION
Small tweak to correct this error I found.

```
$ supernova-keyring -s global user

[Keyring operation] Preparing to set a password in the keyring for:

  - Environment  : global
  - Parameter    : user

If this is correct, enter the corresponding credential to store in your keyring
or press CTRL-D to abort:

Traceback (most recent call last):
  File "/home/carl/.xdg/data/virtualenv/supernova-git/bin/supernova-keyring", line 9, in <module>
    load_entry_point('supernova==0.9.9', 'console_scripts', 'supernova-keyring')()
  File "/home/carl/.xdg/data/virtualenv/supernova-git/lib/python2.7/site-packages/supernova/executable.py", line 107, in run_supernova_keyring
    credentials.set_user_password(args)
  File "/home/carl/.xdg/data/virtualenv/supernova-git/lib/python2.7/site-packages/supernova/credentials.py", line 157, in set_user_password
    "supernova service.\n" % (colors.gwrap("Success"), username))
TypeError: not all arguments converted during string formatting
```
