### PR TITLE
catch exception for NoSectionError

### DIFF
--- a/supernova/supernova.py
+++ b/supernova/supernova.py
@@ -49,7 +49,12 @@ class SuperNova(object):
         Finds relevant config options in the supernova config and cleans them
         up for novaclient.
         """
-        raw_creds = config.nova_creds.items(self.nova_env)
+        try:
+            raw_creds = config.nova_creds.items(self.nova_env)
+        except:
+            msg = "[%s] Unable to locate section '%s' in your configuration."
+            print(msg % (colors.rwrap("Failed"), self.nova_env))
+            sys.exit(1)
         nova_re = re.compile(r"(^nova_|^os_|^novaclient|^trove_)")
 
         creds = []


### PR DESCRIPTION
Users don't like seeing tracebacks.

Before:

```
(env)$ supernova foo list
Traceback (most recent call last):
  File "/home/carl/Projects/github.com/supernova/env/bin/supernova", line 9, in <module>
    load_entry_point('supernova==1.0.1', 'console_scripts', 'supernova')()
  File "/home/carl/Projects/github.com/supernova/supernova/executable.py", line 84, in run_supernova
    snobj.run_novaclient(nova_args, supernova_args)
  File "/home/carl/Projects/github.com/supernova/supernova/supernova.py", line 101, in run_novaclient
    self.prep_shell_environment()
  File "/home/carl/Projects/github.com/supernova/supernova/supernova.py", line 92, in prep_shell_environment
    for key, value in self.prep_nova_creds():
  File "/home/carl/Projects/github.com/supernova/supernova/supernova.py", line 52, in prep_nova_creds
    raw_creds = config.nova_creds.items(self.nova_env)
  File "/usr/lib64/python2.7/ConfigParser.py", line 347, in items
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'foo'
```

After:

```
(env)$ supernova foo list
[Failed] Unable to locate section 'foo' in your configuration.
```
