### PR TITLE
update with Fedora Python packaging guidelines

### DIFF
--- a/supernova.spec
+++ b/supernova.spec
@@ -1,14 +1,16 @@
-%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+%if 0%{?fedora} < 13
+%global __python2 %{_bindir}/python2
+%global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
+%global python2_sitearch %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")
+%endif
 
 Name:           supernova
-Version:        1.0.0
+Version:        1.0.1
 Release:        1%{?dist}
 Summary:        Use novaclient with multiple OpenStack nova environments the easy way
-
 License:        ASLv2
-URL:            https://github.com/rackerhacker/supernova
-Source0:        %{name}-%{version}.tar.gz
-
+URL:            https://github.com/major/supernova
+Source0:        https://pypi.python.org/packages/source/s/%{name}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  python-setuptools
 Requires:       python-keyring
@@ -17,27 +19,35 @@ Requires:       pycryptopp
 Requires:       python-simplejson
 Requires:       python-iso8601
 
+
 %description
 supernova manages multiple nova environments without sourcing
 novarc's or mucking with environment variables.
+
 
 %prep
 %setup -q
 
 
 %build
+%{__python2} setup.py build
 
 
 %install
-rm -rf $RPM_BUILD_ROOT
-%{__python} setup.py install --root $RPM_BUILD_ROOT
+%{__python2} setup.py install --optimize 1 --skip-build --root %{buildroot}
+
 
 %files
-%{python_sitelib}/*
+%{python2_sitelib}/*
 %{_bindir}/supernova
 %{_bindir}/supernova-keyring
 
+
 %changelog
+* Fri Jun 20 2014 Carl George <carl@carlgeorge.us> - 1.0.1-1
+- Version bump to 1.0.1
+- Follow Fedora Python packaging guidelines
+
 * Thu May 29 2014 Greg Swift <gregswift@gmail.com> - 1.0.0-1
 - Version bump to 1.0.0
 


### PR DESCRIPTION
Some spec file updates, mainly based on http://fedoraproject.org/wiki/Packaging:Python, along with other packaging best practices.
