### PR TITLE
Add docs to sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include docs *


### PR DESCRIPTION
When packaging from source we sometimes desire the documentation to be
built for the local system.  This adds the documentation to any future
pypi distributions.
