### PR TITLE
Add contrib and examples to sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
+include contrib/*.bash
 recursive-include docs *
+recursive-include example_configs *


### PR DESCRIPTION
Just noticed I missed these last time.  Again, when building from source
these niceties come in handy if the user so desires them.
