### PR TITLE
fix(completion): don't match ini file comments

### DIFF
--- a/contrib/supernova-completion.bash
+++ b/contrib/supernova-completion.bash
@@ -4,7 +4,7 @@ _supernova()
 {
     local cur=${COMP_WORDS[COMP_CWORD]}
     local configs=$(cat "${XDG_CONFIG_HOME}"/supernova ~/.supernova ./.supernova 2> /dev/null)
-    local possibilities=$(echo "${configs}" | sed -n '/^\[.*\]/ s_\[\(.*\)\]_\1_p' | sort -u)
+    local possibilities=$(echo "${configs}" | sed -n '/^\[.*\]/ s_\[\(.*\)\].*_\1_p' | sort -u)
     COMPREPLY=( $(compgen -W "${possibilities}" -- $cur) )
 }
 complete -F _supernova supernova


### PR DESCRIPTION
e.g.
```ini
[myproject] ; my awesome project
```
was showing completions:
```
;          awesome    my         myproject  project
```