### PR TITLE
add mkdocs.yml to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include contrib/*.bash
+include mkdocs.yml
 recursive-include docs *
 recursive-include example_configs *


### PR DESCRIPTION
docs is included in the sdist but the configuration file, mkdocs.yml,
is not.