### PR TITLE
Fix detection and usage of OS_EXECUTABLE in config file and env vars

### DIFF
--- a/supernova/executable.py
+++ b/supernova/executable.py
@@ -62,8 +62,15 @@ command_settings = {
 
 
 @click.command(context_settings=command_settings)
+# This is a little hacky, but we cannot directly set the default to nova
+# because then we have no way of determining if the option was supplied on the
+# command line, or simply set to the default.  We need that information so that
+# we can properly set the executable to run in this order:
+# 1. executable provided on command line
+# 2. executable from environment variable
+# 3. fallback to nova as a default if neither 1 nor 2 are set
 @click.option('--executable', '-x', default='default',
-              help='Command to run', show_default=True)
+              help='Command to run  [default: nova]', show_default=False)
 @click.option('--debug', '-d', default=False, is_flag=True,
               help="Enable debugging", show_default=True)
 @click.option('--conf', '-c', default=None, is_flag=False,

--- a/supernova/executable.py
+++ b/supernova/executable.py
@@ -62,7 +62,7 @@ command_settings = {
 
 
 @click.command(context_settings=command_settings)
-@click.option('--executable', '-x', default='nova',
+@click.option('--executable', '-x', default='default',
               help='Command to run', show_default=True)
 @click.option('--debug', '-d', default=False, is_flag=True,
               help="Enable debugging", show_default=True)

--- a/supernova/supernova.py
+++ b/supernova/supernova.py
@@ -51,11 +51,13 @@ def check_for_executable(supernova_args, env_vars):
     arguments ONLY IF an executable wasn't set on the command line.  The
     command line executable must take priority.
     """
-    if ('OS_EXECUTABLE' in env_vars.keys() and
-            supernova_args['executable'] == 'default'):
-        supernova_args['executable'] = env_vars['OS_EXECUTABLE']
-    elif supernova_args['executable'] == 'default':
-        supernova_args['executable'] = 'nova'
+    if 'OS_EXECUTABLE' in env_vars.keys():
+        if 'executable' not in supernova_args.keys():
+            supernova_args['executable'] = env_vars['OS_EXECUTABLE']
+        elif supernova_args['executable'] == 'default':
+            supernova_args['executable'] = env_vars['OS_EXECUTABLE']
+        else:
+            supernova_args['executable'] = 'nova'
 
     return supernova_args
 

--- a/supernova/supernova.py
+++ b/supernova/supernova.py
@@ -52,8 +52,10 @@ def check_for_executable(supernova_args, env_vars):
     command line executable must take priority.
     """
     if ('OS_EXECUTABLE' in env_vars.keys() and
-            'executable' not in supernova_args.keys()):
+            supernova_args['executable'] == 'default'):
         supernova_args['executable'] = env_vars['OS_EXECUTABLE']
+    elif supernova_args['executable'] == 'default':
+        supernova_args['executable'] = 'nova'
 
     return supernova_args
 
@@ -95,7 +97,6 @@ def run_command(nova_creds, nova_args, supernova_args):
     env_vars = os.environ.copy()
     env_vars.update(credentials.prep_shell_environment(nova_env,
                                                        nova_creds))
-
     # Check for a debug override
     if supernova_args['debug']:
         nova_args.insert(0, '--debug ')

--- a/supernova/supernova.py
+++ b/supernova/supernova.py
@@ -51,14 +51,13 @@ def check_for_executable(supernova_args, env_vars):
     arguments ONLY IF an executable wasn't set on the command line.  The
     command line executable must take priority.
     """
+    exe = supernova_args.get('executable', 'default')
+    if exe != 'default':
+        return supernova_args
     if 'OS_EXECUTABLE' in env_vars.keys():
-        if 'executable' not in supernova_args.keys():
-            supernova_args['executable'] = env_vars['OS_EXECUTABLE']
-        elif supernova_args['executable'] == 'default':
-            supernova_args['executable'] = env_vars['OS_EXECUTABLE']
-        else:
-            supernova_args['executable'] = 'nova'
-
+        supernova_args['executable'] = env_vars['OS_EXECUTABLE']
+        return supernova_args
+    supernova_args['executable'] = 'nova'
     return supernova_args
 
 


### PR DESCRIPTION
It appears that at some point detection and usage of OS_EXECUTABLE in .supernova and in env vars broke (likely when the change to click was put in place).

This restores that functionality.