### PR TITLE
Add echo option to print environment and exit

### DIFF
--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -104,3 +104,16 @@ class TestExecutable(object):
         result = runner.invoke(executable.run_supernova, command)
         assert result.exit_code != 0
         assert "There's an error in your configuration file" in result.output
+
+    def test_echo(self):
+        runner = CliRunner()
+        result = runner.invoke(executable.run_supernova, ['--echo', 'hkg'])
+        assert result.exit_code == 0
+        assert len(result.output.split('\n')) == 10
+        assert 'OS_REGION_NAME=HKG' in result.output
+
+    def test_echo_group(self):
+        runner = CliRunner()
+        result = runner.invoke(executable.run_supernova, ['--echo', 'raxusa'])
+        assert result.exit_code == 1
+        assert 'group of environments' in result.output


### PR DESCRIPTION
This prints out the specified environment so that users can ```eval $(supernova --echo myenv)``` so supernova-incompatible apps can still use supernova's configuration management.