### PR TITLE
add optional requirements (resolves #86)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,12 @@ required_packages = [
     "six"
 ]
 
+optional_packages = {
+    'rackspace':  [
+        'rackspace-novaclient'
+    ]
+}
+
 setup(
     name='supernova',
     version='2.0.9',
@@ -32,6 +38,7 @@ setup(
     author_email='major@mhtx.net',
     description="novaclient wrapper for multiple nova environments",
     install_requires=required_packages,
+    extras_require=optional_packages,
     packages=['supernova'],
     url='https://github.com/major/supernova',
     entry_points='''


### PR DESCRIPTION
This will allow a user to run `pip install supernova[rackspace]` and have both supernova and rackspace-novaclient installed.  I verified this works when running `pip install -e .[rackspace]` from withing the git repo, and it should work the same once the change is uploaded to PyPI.