### PR TITLE
Capping keyring version temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click
 configobj
-keyring>=0.9.2
+importlib
+keyring<8.0
 python-novaclient
 six

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ from setuptools import setup
 required_packages = [
     "click",
     "configobj",
-    "keyring",
+    "importlib",
+    "keyring<8.0",
     "python-novaclient",
     "six"
 ]


### PR DESCRIPTION
The python keyring module dropped file-based backends in keyring 8.x.
Installing the keyrings.alt module brings it back, but there are other
problems.

Fixes #84.