### PR TITLE
python3 compatible issue fix on -e

### DIFF
--- a/supernova/credentials.py
+++ b/supernova/credentials.py
@@ -18,16 +18,17 @@ Handles all of the interactions with the operating system's keyring
 """
 import re
 
+import keyring
+
+import six
+
+from . import utils
+
 try:
     import gi.require_version
     gi.require_version('GnomeKeyring', '1.0')
 except ImportError:
     pass
-
-import keyring
-
-
-from . import utils
 
 
 def get_user_password(env, param, force=False):
@@ -115,6 +116,8 @@ def prep_shell_environment(nova_env, nova_creds):
     new_env = {}
 
     for key, value in prep_nova_creds(nova_env, nova_creds):
+        if type(value) == six.binary_type:
+            value = value.decode()
         new_env[key] = value
 
     return new_env


### PR DESCRIPTION
with python supernova -e command outputs password as b'<password>'
so if environ is bytes type then convert string type

if credential stores in keychain , OS_PASSWORD will ouput as b'password' notation..
```
$ supernova -e staging-stage-v1
________________________________________________________________________________
SUPERNOVA_GROUP=group
OS_USERNAME=user
OS_REGION_NAME=RegionOne
OS_AUTH_URL=https://my-openstack:5000/v2.0
OS_PASSWORD=b'password'
OS_TENANT_NAME=username
```