### PR TITLE
Add a default `all` group

### DIFF
--- a/docs/usingsupernova.md
+++ b/docs/usingsupernova.md
@@ -121,6 +121,12 @@ You can also use a comma-separated list of group names:
     supernova raxusa,raxuk list
 ```
 
+There is a default group called `all` that contains all environments.
+You can use the `all` group without having to add `SUPERNOVA_GROUP`
+settings to your config file:
+
+    supernova all list
+
 ## Using supernova with different executables
 
 While supernova uses the nova executable by default, you can configure it to use any other executable when it runs.  For example, you could use it to run glance, neutron, or keystone.

--- a/supernova/utils.py
+++ b/supernova/utils.py
@@ -68,6 +68,8 @@ def get_envs_in_group(group_name, nova_creds):
             supernova_groups = [supernova_groups]
         if group_name in supernova_groups:
             envs.append(key)
+        elif group_name == 'all':
+            envs.append(key)
     return envs
 
 
@@ -93,6 +95,7 @@ def is_valid_group(group_name, nova_creds):
         if hasattr(supernova_groups, 'startswith'):
             supernova_groups = [supernova_groups]
         valid_groups.extend(supernova_groups)
+    valid_groups.append('all')
     if group_name in valid_groups:
         return True
     else:

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -128,6 +128,15 @@ class TestExecutable(object):
         assert result.exit_code == 0
         assert "Successfully stored" in result.output
 
+    def test_all_group(self, monkeypatch):
+        def mockreturn(nova_creds, nova_args, supernova_args):
+            return 0
+        monkeypatch.setattr(supernova, "run_command", mockreturn)
+        runner = CliRunner()
+        command = ['all', 'list']
+        result = runner.invoke(executable.run_supernova, command)
+        assert result.exit_code == 0
+
     def test_valid_group(self, monkeypatch):
         def mockreturn(nova_creds, nova_args, supernova_args):
             return 0


### PR DESCRIPTION
that contains all environments

so you can do stuff like:

    supernova all list

without having to add `SUPERNOVA_GROUP` settings to your config file.

Cc: @major, @sudarkoff