### PR TITLE
Allow comma-separated list for SUPERNOVA_GROUP

### DIFF
--- a/docs/usingsupernova.md
+++ b/docs/usingsupernova.md
@@ -85,6 +85,20 @@ Starting in supernova 0.9.6, you can "group" environments and run commands acros
     SUPERNOVA_GROUP=raxusa
     ...snip...
 
+You can also use a comma-separated list for `SUPERNOVA_GROUP`:
+
+    [dfw]
+    SUPERNOVA_GROUP=raxusa,rackspace,dallas,usa
+    ...snip...
+
+    [ord]
+    SUPERNOVA_GROUP=raxusa,rackspace,chicago,usa
+    ...snip...
+
+    [iad]
+    SUPERNOVA_GROUP=raxusa,rackspace,virginia,usa
+    ...snip...
+
 Instead of referring to these environments one by one, you can now run commands across them as a group:
 
     supernova raxusa list

--- a/supernova/credentials.py
+++ b/supernova/credentials.py
@@ -136,9 +136,11 @@ def prep_nova_creds(nova_env, nova_creds):
 
     creds = []
     for param, value in raw_creds.items():
-
         if not proxy_re.match(param):
             param = param.upper()
+
+        if not hasattr(value, 'startswith'):
+            continue
 
         # Get values from the keyring if we find a USE_KEYRING constant
         if value.startswith("USE_KEYRING"):

--- a/supernova/utils.py
+++ b/supernova/utils.py
@@ -62,10 +62,12 @@ def get_envs_in_group(group_name, nova_creds):
     configuration line that matches the group_name.
     """
     envs = []
-    for section in nova_creds.keys():
-        if ('SUPERNOVA_GROUP' in nova_creds[section] and
-                nova_creds[section]['SUPERNOVA_GROUP'] == group_name):
-            envs.append(section)
+    for key, value in nova_creds.items():
+        supernova_groups = value.get('SUPERNOVA_GROUP', [])
+        if hasattr(supernova_groups, 'startswith'):
+            supernova_groups = [supernova_groups]
+        if group_name in supernova_groups:
+            envs.append(key)
     return envs
 
 
@@ -85,9 +87,12 @@ def is_valid_group(group_name, nova_creds):
     Checks to see if the configuration file contains a SUPERNOVA_GROUP
     configuration option.
     """
-    valid_groups = [value['SUPERNOVA_GROUP'] for key, value in
-                    nova_creds.items() if 'SUPERNOVA_GROUP'
-                    in nova_creds[key].keys()]
+    valid_groups = []
+    for key, value in nova_creds.items():
+        supernova_groups = value.get('SUPERNOVA_GROUP', [])
+        if hasattr(supernova_groups, 'startswith'):
+            supernova_groups = [supernova_groups]
+        valid_groups.extend(supernova_groups)
     if group_name in valid_groups:
         return True
     else:

--- a/tests/configs/rax_without_keyring
+++ b/tests/configs/rax_without_keyring
@@ -1,5 +1,5 @@
 [dfw]
-SUPERNOVA_GROUP=raxusa
+SUPERNOVA_GROUP=raxusa,dallas,usa
 OS_AUTH_URL=https://identity.api.rackspacecloud.com/v2.0/
 OS_AUTH_SYSTEM=rackspace
 OS_COMPUTE_API_VERSION=1.1
@@ -11,7 +11,7 @@ OS_USERNAME=my_username
 OS_TENANT_NAME=my_tenant
 
 [ord]
-SUPERNOVA_GROUP=raxusa
+SUPERNOVA_GROUP=raxusa,chicago,usa
 OS_AUTH_SYSTEM=rackspace
 OS_AUTH_URL=https://identity.api.rackspacecloud.com/v2.0/
 OS_COMPUTE_API_VERSION=1.1
@@ -23,7 +23,7 @@ OS_USERNAME=my_username
 OS_TENANT_NAME=my_tenant
 
 [iad]
-SUPERNOVA_GROUP=raxusa
+SUPERNOVA_GROUP=raxusa,virginia,usa
 OS_AUTH_SYSTEM=rackspace
 OS_AUTH_URL=https://identity.api.rackspacecloud.com/v2.0/
 OS_COMPUTE_API_VERSION=1.1
@@ -35,6 +35,7 @@ OS_USERNAME=my_username
 OS_TENANT_NAME=my_tenant
 
 [syd]
+SUPERNOVA_GROUP=sydney,australia
 OS_AUTH_SYSTEM=rackspace
 OS_AUTH_URL=https://syd.identity.api.rackspacecloud.com/v2.0/
 OS_COMPUTE_API_VERSION=1.1
@@ -46,6 +47,7 @@ OS_USERNAME=my_username
 OS_TENANT_NAME=my_tenant
 
 [hkg]
+SUPERNOVA_GROUP=hong_kong,china
 OS_AUTH_SYSTEM=rackspace
 OS_AUTH_URL=https://identity.api.rackspacecloud.com/v2.0/
 OS_COMPUTE_API_VERSION=1.1


### PR DESCRIPTION
E.g.:

```ini
[dfw]
SUPERNOVA_GROUP=raxusa,rackspace,dallas,usa
```

to make the `dfw` environment a member of all the listed groups.

Cc: @major, @sudarkoff