### PR TITLE
Add --dashboard

### DIFF
--- a/.supernova
+++ b/.supernova
@@ -1,5 +1,6 @@
 # This is an example config for use with tests
 [dfw]
+SUPERNOVA_DASHBOARD_URL=https://dfw.dashboard.rackspacecloud.com/
 SUPERNOVA_GROUP=raxusa
 OS_AUTH_URL=https://identity.api.rackspacecloud.com/v2.0/
 OS_AUTH_SYSTEM=rackspace

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,3 +1,5 @@
+import webbrowser
+
 from click.testing import CliRunner
 
 
@@ -110,6 +112,29 @@ class TestExecutable(object):
         result = runner.invoke(executable.run_supernova, command)
         assert result.exit_code != 0
         assert "There's an error in your configuration file" in result.output
+
+    def test_dashboard(self, monkeypatch):
+        def mockreturn(url):
+            return False
+        monkeypatch.setattr(webbrowser, "open", mockreturn)
+        runner = CliRunner()
+        result = runner.invoke(executable.run_supernova,
+                               ['--dashboard', 'dfw'])
+        assert result.exit_code == 0
+
+    def test_dashboard_group(self):
+        runner = CliRunner()
+        result = runner.invoke(executable.run_supernova,
+                               ['--dashboard', 'raxusa'])
+        assert result.exit_code == 1
+        assert 'group of environments' in result.output
+
+    def test_dashboard_no_url(self):
+        runner = CliRunner()
+        result = runner.invoke(executable.run_supernova,
+                               ['--dashboard', 'hkg'])
+        assert result.exit_code == 1
+        assert 'No SUPERNOVA_DASHBOARD_URL' in result.output
 
     def test_echo(self):
         runner = CliRunner()


### PR DESCRIPTION
Opens the dashboard URL specified in `SUPERNOVA_DASHBOARD_URL` in a web browser.

e.g.:

If you have in your config:

    [dfw]
    SUPERNOVA_DASHBOARD_URL=https://dfw.dashboard.rackspacecloud.com/
    ... snip ...

Then:

    $ supernova --dashboard dfw

would open https://dfw.dashboard.rackspacecloud.com/ in a web browser.