### PR TITLE
Make --list & --shortlist honor custom config file

### DIFF
--- a/supernova/executable.py
+++ b/supernova/executable.py
@@ -32,7 +32,18 @@ from . import utils
 def print_env_list(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    nova_creds = config.run_config()
+
+    conf = ctx.params.get('conf')
+
+    # Retrieve our credentials from the configuration file
+    try:
+        nova_creds = config.run_config(config_file_override=conf)
+    except Exception as e:
+        msg = ("\n  There's an error in your configuration file:\n\n"
+               "    {0}\n").format(e)
+        click.echo(msg)
+        ctx.exit(1)
+
     for env in nova_creds.keys():
         nova_env = dict(nova_creds.get('DEFAULT', {}), **nova_creds[env])
         envheader = '__ %s ' % click.style(env, fg='green')
@@ -45,7 +56,18 @@ def print_env_list(ctx, param, value):
 def print_env_short_list(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    nova_creds = config.run_config()
+
+    conf = ctx.params.get('conf')
+
+    # Retrieve our credentials from the configuration file
+    try:
+        nova_creds = config.run_config(config_file_override=conf)
+    except Exception as e:
+        msg = ("\n  There's an error in your configuration file:\n\n"
+               "    {0}\n").format(e)
+        click.echo(msg)
+        ctx.exit(1)
+
     row = 1
     for nova_env in nova_creds.keys():
         executable = "nova"

--- a/tests/configs/test_list_specify_config_file
+++ b/tests/configs/test_list_specify_config_file
@@ -1,0 +1,11 @@
+[test_list_specify_config_file]
+SUPERNOVA_GROUP=raxusa
+OS_AUTH_URL=https://identity.api.rackspacecloud.com/v2.0/
+OS_AUTH_SYSTEM=rackspace
+OS_COMPUTE_API_VERSION=1.1
+NOVA_RAX_AUTH=1
+OS_REGION_NAME=DFW
+NOVA_SERVICE_NAME=cloudServersOpenStack
+OS_PASSWORD=my_password
+OS_USERNAME=my_username
+OS_TENANT_NAME=my_tenant

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -18,11 +18,43 @@ class TestExecutable(object):
         assert result.exit_code == 0
         assert "dfw" in result.output
 
+    def test_list_specify_config_file(self):
+        runner = CliRunner()
+        command = ['-c', 'tests/configs/test_list_specify_config_file',
+                   '--list']
+        result = runner.invoke(executable.run_supernova, command)
+        assert result.exit_code == 0
+        assert "test_list_specify_config_file" in result.output
+
+    def test_list_broken_configuration_file(self):
+        runner = CliRunner()
+        command = ['-c', 'tests/configs/rax_without_keyring_malformed',
+                   '--list']
+        result = runner.invoke(executable.run_supernova, command)
+        assert result.exit_code != 0
+        assert "There's an error in your configuration file" in result.output
+
     def test_shortlist_output(self):
         runner = CliRunner()
         result = runner.invoke(executable.run_supernova, ['--shortlist'])
         assert result.exit_code == 0
         assert "dfw" in result.output
+
+    def test_shortlist_specify_config_file(self):
+        runner = CliRunner()
+        command = ['-c', 'tests/configs/test_list_specify_config_file',
+                   '--shortlist']
+        result = runner.invoke(executable.run_supernova, command)
+        assert result.exit_code == 0
+        assert "test_list_specify_config_file" in result.output
+
+    def test_shortlist_broken_configuration_file(self):
+        runner = CliRunner()
+        command = ['-c', 'tests/configs/rax_without_keyring_malformed',
+                   '--shortlist']
+        result = runner.invoke(executable.run_supernova, command)
+        assert result.exit_code != 0
+        assert "There's an error in your configuration file" in result.output
 
     def test_get_credential_success(self):
         runner = CliRunner()


### PR DESCRIPTION
This makes it so that `--list` (`-l`) and `--shortlist` (`-s`) use any custom config file specified by the `--conf` (`-c`) option.

Previously, if I ran:

    supernova -c ~/.supernova -l

or:

    supernova -c ~/.supernova -s

in the directory of the supernova git repo, it would always list the environments specified in `./.supernova` instead of the environments in `~/.supernova`.