### PR TITLE
Support dynamic config w/ OS_TENANT_NAME

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -92,7 +92,7 @@ When supernova runs, it will take the configuration options and pass them direct
 
 For accounts where you would like to utilize the same configuration, it is possible to use the same entry.
 
-In the configuration, you can separate the regions by a semicolon::
+In the configuration, you can separate the regions by a semicolon:
 
     [personal]
     ..snip..
@@ -101,11 +101,24 @@ In the configuration, you can separate the regions by a semicolon::
     OS_USERNAME=username
     OS_PASSWORD=somelongapikey
 
-
 This will create the super group "personal" as well as the individual groups "personal-DFW" and "personal-ORD"::
 
     > supernova -l | grep personal
     -- personal-DFW -------------------------------------------------------------
       SUPERNOVA_GROUP      : personal
     -- personal-ORD -------------------------------------------------------------
+      SUPERNOVA_GROUP      : personal
+
+You can also use dynamic configuration with tenants (in the `OS_TENANT_NAME` setting):
+
+    [personal]
+    ..snip..
+    OS_TENANT_NAME=dev;prod
+    OS_USERNAME=username
+    OS_PASSWORD=somelongapikey
+
+    > supernova -l | grep personal
+    -- personal-dev -------------------------------------------------------------
+      SUPERNOVA_GROUP      : personal
+    -- personal-prod -------------------------------------------------------------
       SUPERNOVA_GROUP      : personal

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,3 +78,26 @@ class TestDynamicConfig(object):
                result['dynamic-section-ORD'].get('OS_REGION_NAME')
         assert 'DFW' == \
                result['dynamic-section-DFW'].get('OS_REGION_NAME')
+
+    def test_dynamic_sections_using_tenant(self):
+        result = config.load_config()
+        result['dynamic-section'] = {'OS_TENANT_NAME': "dev;prod"}
+        config.create_dynamic_configs(result)
+        # The new sections exist
+        assert 'dynamic-section-dev' in result.sections
+        assert 'dynamic-section-prod' in result.sections
+
+        # The default section is no longer provided
+        assert 'dynamic-section' not in result.sections
+
+        # The super group is set up correctly
+        assert 'dynamic-section' in \
+               result['dynamic-section-dev'].get('SUPERNOVA_GROUP')
+        assert 'dynamic-section' == \
+               result['dynamic-section-prod'].get('SUPERNOVA_GROUP')
+
+        # The regions are correct
+        assert 'dev' == \
+               result['dynamic-section-dev'].get('OS_TENANT_NAME')
+        assert 'prod' == \
+               result['dynamic-section-prod'].get('OS_TENANT_NAME')


### PR DESCRIPTION
Support dynamic config with `OS_TENANT_NAME` in addition to `OS_REGION_NAME`.

E.g.:

    [sjc]
    ... snip ...
    OS_TENANT_NAME=dev;test;production
    ... snip ...

Cc: @major, @sudarkoff