### PR TITLE
Allow regex pattern for environment name

### DIFF
--- a/docs/usingsupernova.md
+++ b/docs/usingsupernova.md
@@ -38,6 +38,16 @@ You can also use a comma-separated list of environment names:
     supernova iad,dfw,ord list
 ```
 
+You can use a regular expression for the environment if you enclose it
+in slashes:
+
+```html
+    supernova /^rax/ list
+```
+
+The above command will execute `nova list` for every environment whose
+name starts with `rax`.
+
 You can use supernova with long-running options and the output will be piped live to your terminal.  For example, you can use `--poll` when you boot an instance and you'll see the novaclient output update as your instance is being built.
 
 For debug output, supernova accepts `--debug` as a supernova option or as a novaclient option.  Both of these are okay:

--- a/supernova/executable.py
+++ b/supernova/executable.py
@@ -17,6 +17,7 @@
 Contains the functions needed for supernova and supernova-keyring commands
 to run
 """
+import re
 import sys
 import webbrowser
 
@@ -177,6 +178,9 @@ def run_supernova(ctx, executable, debug, quiet, environment, command, conf,
                 envs.extend(utils.get_envs_in_group(env, nova_creds))
             else:
                 envs.append(env)
+    elif environment.startswith('/') and environment.endswith('/'):
+        envs = [nova_env for nova_env in nova_creds.keys()
+                if re.search(environment[1:-1], nova_env)]
     else:
         envs = [environment]
 

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -155,6 +155,19 @@ class TestExecutable(object):
         result = runner.invoke(executable.run_supernova, command)
         assert result.exit_code == 0
 
+    def test_env_regex(self, monkeypatch):
+        envs = []
+
+        def mockreturn(nova_creds, nova_args, supernova_args):
+            envs.append(supernova_args['nova_env'])
+            return 0
+        monkeypatch.setattr(supernova, "run_command", mockreturn)
+        runner = CliRunner()
+        command = ['/^s/', 'list']
+        result = runner.invoke(executable.run_supernova, command)
+        assert result.exit_code == 0
+        assert envs == ['syd', 'someinova']
+
     def test_broken_configuration_file(self):
         runner = CliRunner()
         command = ['-c', 'tests/configs/rax_without_keyring_malformed', 'dfw',


### PR DESCRIPTION
when environment name begins and ends with a slash.

E.g.:

    supernova /^rax/ list

The above command will execute `nova list` for every environment whose name starts with `rax`.

Cc: @major, @sudarkoff