### PR TITLE
python3 compatible issue fix on -e

### DIFF
--- a/supernova/credentials.py
+++ b/supernova/credentials.py
@@ -18,16 +18,17 @@ Handles all of the interactions with the operating system's keyring
 """
 import re
 
+import keyring
+
+import six
+
+from . import utils
+
 try:
     import gi.require_version
     gi.require_version('GnomeKeyring', '1.0')
 except ImportError:
     pass
-
-import keyring
-
-
-from . import utils
 
 
 def get_user_password(env, param, force=False):
@@ -115,6 +116,8 @@ def prep_shell_environment(nova_env, nova_creds):
     new_env = {}
 
     for key, value in prep_nova_creds(nova_env, nova_creds):
+        if type(value) == six.binary_type:
+            value = value.decode()
         new_env[key] = value
 
     return new_env

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -169,3 +169,26 @@ class TestCredentials(object):
         result = credentials.set_user_password(environment, parameter,
                                                password)
         assert result
+
+    def test_prep_shell_environment(self):
+        nova_env = 'prod'
+        nova_creds = {
+            'prod': {
+                'OS_PASSWORD': 'USE_KEYRING'
+            }
+        }
+        result = credentials.prep_shell_environment(nova_env, nova_creds)
+        assert result == {'OS_PASSWORD': 'password from TestKeyring'}
+
+    def test_prep_shell_environment_unicode(self, monkeypatch):
+        def mockreturn(nova_env, param, value):
+            return ('OS_PASSWORD', u'password from TestKeyring')
+        monkeypatch.setattr(credentials, "pull_env_credential", mockreturn)
+        nova_env = 'prod'
+        nova_creds = {
+            'prod': {
+                'OS_PASSWORD': 'USE_KEYRING'
+            }
+        }
+        result = credentials.prep_shell_environment(nova_env, nova_creds)
+        assert result == {'OS_PASSWORD': 'password from TestKeyring'}


### PR DESCRIPTION
With python3, `supernova -e` command outputs password as `bytes` (e.g.: `b'password'`).
So if environ is `bytes` type, then convert to `str` type.

If credential is stored in keychain, `OS_PASSWORD` will output as `b'password'`. This PR fixes that.

```
$ supernova -e staging-stage-v1
________________________________________________________________________________
SUPERNOVA_GROUP=group
OS_USERNAME=user
OS_REGION_NAME=RegionOne
OS_AUTH_URL=https://my-openstack:5000/v2.0
OS_PASSWORD=b'password'
OS_TENANT_NAME=username
```

This is an amended version of #112 from @whitekid, which had failing tests because coverage dropped and it never got updated.