### PR TITLE
Add config directory support

### DIFF
--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -176,6 +176,14 @@ class TestExecutable(object):
         assert result.exit_code != 0
         assert "There's an error in your configuration file" in result.output
 
+    def test_broken_configuration_directory(self):
+        runner = CliRunner()
+        command = ['-c', 'tests/configs/', 'dfw',
+                   'list']
+        result = runner.invoke(executable.run_supernova, command)
+        assert "Skipping 'tests/configs/rax_without_keyring_malformed', "
+        "Parsing Error." in result.output
+
     def test_dashboard(self, monkeypatch):
         def mockreturn(url):
             return False


### PR DESCRIPTION
This takes @rtrox's work in GH-93 and cleans it up a bit; pretty much just taking out unrelated changes that were inadvertently included.

@rtrox deserves credit for the feature.

This lets one have a directory full of supernova config files -- e.g.:

```
$ ls -l ~/.config/supernova.d/
total 32
-rw-r--r--+ 1 marca  staff  406 Jul  8 11:00 az1.ini
-rw-r--r--+ 1 marca  staff  409 Jul  8 10:59 az2.ini
-rw-r--r--+ 1 marca  staff  348 Jul  8 11:00 az3.ini
-rw-r--r--+ 1 marca  staff  348 Jul  8 11:00 az4.ini
```

This closes #93.