### PR TITLE
Fix Pep8 violation in unit test

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -10,6 +10,7 @@ class MockGi(object):
         cls.called += 1
         return True
 
+
 if getattr(sys.version_info, 'major', 2) == 3:
     import builtins
 


### PR DESCRIPTION
    ./tests/test_imports.py:13:1: E305 expected 2 blank lines after
    class or function definition, found 1