### PR TITLE
add support for packaging as a Python wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
This package works with both Python 2 and Python 3 and doesn't use any C
extensions so it should be compatible with being an univerisal wheel.