### PR TITLE
tox: update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,17 @@ matrix:
       env: TOXENV=py26
     - python: "2.7"
       env: TOXENV=py27
-    - python: "3.3"
-      env: TOXENV=py33
     - python: "3.4"
       env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
     - python: "pypy"
       env: TOXENV=pypy
     - python: 2.7
       env: TOXENV=pep8
-    - python: 3.3
+    - python: 3.6
       env: TOXENV=py3pep8
 before_install:
   pip install codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {pypy,pep8,py3pep8,py26,py27,py33,py34}
+envlist = {pypy,pep8,py3pep8,py26,py27,py34,py35,py36}
 
 [testenv]
 deps =
@@ -20,7 +20,7 @@ commands =
     flake8 .
 
 [testenv:py3pep8]
-basepython = python3.3
+basepython = python3.6
 deps =
     flake8
     flake8-import-order


### PR DESCRIPTION
Python 3.3 has not had support for a while and other branches are
failing due to attempting to test on it. Python 3.4 is shipped in EPEL
for CentOS 7 so there's some value in starting with that as a valid
version.